### PR TITLE
Remove named arg from `n_distinct()`

### DIFF
--- a/R/mapTrips.R
+++ b/R/mapTrips.R
@@ -106,7 +106,7 @@ mapTrips <- function(trips, colony, IDs=NULL, colorBy = c("complete", "trip")) {
              colID = as.character(
                x = factor(
                  x = .data$tripID,
-                 labels = seq_len(length.out = n_distinct(x = .data$tripID))
+                 labels = seq_len(length.out = n_distinct(.data$tripID))
                  ))) %>%
       arrange(.data$ID, .data$DateTime) -> forplot
 
@@ -136,7 +136,7 @@ mapTrips <- function(trips, colony, IDs=NULL, colorBy = c("complete", "trip")) {
       dplyr::mutate(complete = ifelse(.data$Returns == "No", "No", "Yes"),
                     colID = as.character(x = factor(
         x = .data$tripID,
-        labels = seq_len(length.out = n_distinct(x = .data$tripID))
+        labels = seq_len(length.out = n_distinct(.data$tripID))
       ))) -> forplot
     TRACKPLOT <- ggplot(data = forplot,
                         aes_string(x = "Longitude", y = "Latitude",


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

`n_distinct()` now checks that the `...` are unnamed. You were supplying `x =`; I assume you thought that the first argument to `n_distinct()` was `x` rather than `...`. This is now an error.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!